### PR TITLE
ClassCastException on 'clojure.data.json/print-json'

### DIFF
--- a/src/main/clojure/clojure/data/json.clj
+++ b/src/main/clojure/clojure/data/json.clj
@@ -328,7 +328,7 @@
         to turn off \\uXXXX escapes of Unicode characters."
   [x & options]
   (let [{:keys [escape-unicode] :or {escape-unicode true}} options]
-    (write-json x *out* escape-unicode)))
+    (write-json x (PrintWriter. *out*) escape-unicode)))
 
 
 ;;; JSON PRETTY-PRINTER


### PR DESCRIPTION
I was getting ClassCastExceptions when trying to print out simple Hashes or Strings. 

user => (clojure.data.json/print-json "tim")
ClassCastException java.io.OutputStreamWriter cannot be cast to java.io.PrintWriter  clojure.data.json/write-json-string (json.clj:229)

user=> (clojure.data.json/print-json [1 2 3]) 
ClassCastException java.io.OutputStreamWriter cannot be cast to java.io.PrintWriter  clojure.data.json/write-json-array (json.clj:254)

user => (clojure.data.json/print-json { :a { :aa "b" } } ) 
ClassCastException java.io.OutputStreamWriter cannot be cast to java.io.PrintWriter  clojure.data.json/write-json-object (json.clj:238)

The is that _out_ is a OutputStreamWriter while the functions in question, use a PrintWriter. 
