### PR TITLE
Fix for error writing strings with characters outside the BMP

### DIFF
--- a/src/test/clojure/clojure/data/json_test.clj
+++ b/src/test/clojure/clojure/data/json_test.clj
@@ -27,6 +27,10 @@
 (deftest handles-unicode-escapes
   (is (= " \u0beb " (read-json "\" \\u0bEb \""))))
 
+(deftest handles-unicode-outside-bmp
+  (is (= "\"smiling face: \uD83D\uDE03\""
+         (json-str "smiling face: \uD83D\uDE03" :escape-unicode false))))
+
 (deftest handles-escaped-whitespace
   (is (= "foo\nbar" (read-json "\"foo\\nbar\"")))
   (is (= "foo\rbar" (read-json "\"foo\\rbar\"")))


### PR DESCRIPTION
Hello, 

one of my users decided to start sending Emoji happy faces over a network protocol encoded using data.json, which caused it to promptly roll over and die. It turned out that write-json-string, while aware of the code point vs. character issue, was still iterating over a character count not a code point count.

This change fixes this. I've copied the "codepoints" fn from contrib.string since I couldn't find it anywhere in the 1.3 universe.
