### PR TITLE
add a return value type hint

### DIFF
--- a/src/main/clojure/clojure/data/json.clj
+++ b/src/main/clojure/clojure/data/json.clj
@@ -309,7 +309,7 @@
   Valid options are:
     :escape-unicode false
         to turn of \\uXXXX escapes of Unicode characters."
-  [x & options]
+  ^String [x & options]
   (let [{:keys [escape-unicode] :or {escape-unicode true}} options
 	sw (StringWriter.)
         out (PrintWriter. sw)]


### PR DESCRIPTION
add string return type so library consumers don't need to use type hints when calling methods on the returned String
