### PR TITLE
Adding Failing tests for NaN values

### DIFF
--- a/src/test/clojure/clojure/data/json_test.clj
+++ b/src/test/clojure/clojure/data/json_test.clj
@@ -68,6 +68,12 @@
 (deftest disallows-unclosed-objects
   (is (thrown? Exception (read-json "{\"a\":1,  "))))
 
+(deftest disallows-double-NaN
+  (is (thrown? Exception (json-str (Double/NaN)))))
+
+(deftest disallows-float-NaN
+  (is (thrown? Exception (json-str (Float/NaN)))))
+
 (deftest can-get-string-keys
   (is (= {"a" [1 2 {"b" [3 "four"]} 5.5]}
          (read-json "{\"a\":[1,2,{\"b\":[3,\"four\"]},5.5]}" false true nil))))


### PR DESCRIPTION
NaN is not a valid JSON value, so I added 2 failing tests to expect a thrown exception when trying to json-str a Double/NaN or Float/NaN. I'm not sure if throwing an exception should be the expected value, but the value NaN is not correct.
