### PR TITLE
Fast way to print indented json

### DIFF
--- a/src/main/clojure/clojure/data/json.clj
+++ b/src/main/clojure/clojure/data/json.clj
@@ -282,6 +282,16 @@
 (def ^{:dynamic true :private true} *escape-unicode*)
 (def ^{:dynamic true :private true} *escape-js-separators*)
 (def ^{:dynamic true :private true} *escape-slash*)
+(def ^{:dynamic true :private true} *indent*)
+(def ^{:dynamic true :private true} *indent-depth* 0)
+
+(defn- write-indent [^PrintWriter out]
+  (when *indent*
+    (.print out \newline)
+    (loop [i *indent-depth*]
+      (when (pos? i)
+        (.print out "  ")
+        (recur (dec i))))))
 
 (defprotocol JSONWriter
   (-write [object out]
@@ -316,39 +326,51 @@
     (.append sb \")
     (.print out (str sb))))
 
-(defn- write-object [m ^PrintWriter out] 
+(defn- write-object [m ^PrintWriter out]
   (.print out \{)
-  (loop [x m, have-printed-kv false]
-    (when (seq m)
-      (let [[k v] (first x)
-            out-key (*key-fn* k)
-            out-value (*value-fn* k v)
-            nxt (next x)]
-        (when-not (string? out-key)
-          (throw (Exception. "JSON object keys must be strings")))
-        (if-not (= *value-fn* out-value)
-          (do
-            (when have-printed-kv
-              (.print out \,))
-            (write-string out-key out)
-            (.print out \:)
-            (-write out-value out)
-            (when (seq nxt)
-              (recur nxt true)))
-          (when (seq nxt)
-            (recur nxt have-printed-kv))))))
+  (when (seq m)
+    (binding [*indent-depth* (inc *indent-depth*)]
+      (write-indent out)
+      (loop [x m, have-printed-kv false]
+        (when (seq x)
+          (let [[k v] (first x)
+                out-key (*key-fn* k)
+                out-value (*value-fn* k v)
+                nxt (next x)]
+            (when-not (string? out-key)
+              (throw (Exception. "JSON object keys must be strings")))
+            (if-not (= *value-fn* out-value)
+              (do
+                (when have-printed-kv
+                  (.print out \,)
+                  (write-indent out))
+                (write-string out-key out)
+                (.print out \:)
+                (when *indent*
+                  (.print out \space))
+                (-write out-value out)
+                (when (seq nxt)
+                  (recur nxt true)))
+              (when (seq nxt)
+                (recur nxt have-printed-kv)))))))
+    (write-indent out))
   (.print out \}))
 
 (defn- write-array [s ^PrintWriter out]
   (.print out \[)
-  (loop [x s]
-    (when (seq x)
-      (let [fst (first x)
-            nxt (next x)]
-        (-write fst out)
-        (when (seq nxt)
-          (.print out \,)
-          (recur nxt)))))
+  (when (seq s)
+    (binding [*indent-depth* (inc *indent-depth*)]
+      (write-indent out)
+      (loop [x s]
+        (when (seq x)
+          (let [fst (first x)
+                nxt (next x)]
+            (-write fst out)
+            (when (seq nxt)
+              (.print out \,)
+              (write-indent out)
+              (recur nxt))))))
+    (write-indent out))
   (.print out \]))
 
 (defn- write-bignum [x ^PrintWriter out]
@@ -402,6 +424,12 @@
   "Write JSON-formatted output to a java.io.Writer. Options are
    key-value pairs, valid options are:
 
+    :indent boolean
+
+       If true, will add additional spaces and newlines to do
+       indentation for nested objects and arrays. Works much faster
+       than pprint.
+
     :escape-unicode boolean
 
        If true (default) non-ASCII characters are escaped as \\uXXXX
@@ -438,13 +466,15 @@
         returns itself, the key-value pair will be omitted from the
         output. This option does not apply to non-map collections."
   [x ^Writer writer & options]
-  (let [{:keys [escape-unicode escape-js-separators escape-slash key-fn value-fn]
-         :or {escape-unicode true
+  (let [{:keys [indent escape-unicode escape-js-separators escape-slash key-fn value-fn]
+         :or {indent false
+              escape-unicode true
               escape-js-separators true
               escape-slash true
               key-fn default-write-key-fn
               value-fn default-value-fn}} options]
-    (binding [*escape-unicode* escape-unicode
+    (binding [*indent* indent
+              *escape-unicode* escape-unicode
               *escape-js-separators* escape-js-separators
               *escape-slash* escape-slash
               *key-fn* key-fn
@@ -485,7 +515,7 @@
 
 (defn pprint
   "Pretty-prints JSON representation of x to *out*. Options are the
-  same as for write except :value-fn, which is not supported."
+  same as for write except :indent and :value-fn, which are not supported."
   [x & options]
   (let [{:keys [escape-unicode escape-slash key-fn]
          :or {escape-unicode true

--- a/src/test/clojure/clojure/data/json_test.clj
+++ b/src/test/clojure/clojure/data/json_test.clj
@@ -265,6 +265,42 @@
 (deftest characters-in-map-keys-are-escaped
   (is (= (json/write-str {"\"" 42}) "{\"\\\"\":42}")))
 
+;;; Indent
+
+(deftest print-json-arrays-indent
+  (is (= "[\n  1,\n  2,\n  3\n]" (json/write-str [1 2 3] :indent true)))
+  (is (= "[\n  1,\n  2,\n  3\n]" (json/write-str (list 1 2 3) :indent true)))
+  (is (= "[\n  1,\n  2,\n  3\n]" (json/write-str (sorted-set 1 2 3) :indent true)))
+  (is (= "[\n  1,\n  2,\n  3\n]" (json/write-str (seq [1 2 3]) :indent true))))
+
+(deftest print-java-arrays-indent
+ (is (= "[\n  1,\n  2,\n  3\n]" (json/write-str (into-array [1 2 3]) :indent true))))
+
+(deftest print-empty-arrays-indent
+  (is (= "[]" (json/write-str [] :indent true)))
+  (is (= "[]" (json/write-str (list) :indent true)))
+  (is (= "[]" (json/write-str #{} :indent true))))
+
+(deftest print-json-objects-indent
+  (is (= "{\n  \"a\": 1,\n  \"b\": 2\n}" (json/write-str (sorted-map :a 1 :b 2) :indent true))))
+
+(deftest print-empty-objects-indent
+  (is (= "{}" (json/write-str {} :indent true))))
+
+(deftest print-json-nested-indent
+  (is (=
+"{
+  \"a\": {
+    \"b\": [
+      1,
+      2
+    ],
+    \"c\": [],
+    \"d\": {}
+  }
+}" (json/write-str {:a (sorted-map :b [1 2] :c [] :d {})} :indent true))))
+
+
 ;;; Pretty-printer
 
 (deftest pretty-printing


### PR DESCRIPTION
Hi!

`pprint-json` is dead slow because it tries to fit lines within some length. In practice it takes 20–100 times more time to use `pprint-json` instead of `write-str`, up to the point where it just cannot be used in production:

```
clojure.data.json=> (def data (read-string (slurp "sample.edn")))
#'clojure.data.json/data
clojure.data.json=> (count data)
4613
clojure.data.json=> (time (do (clojure.data.json/write-str data) nil))
"Elapsed time: 219.33 msecs"
clojure.data.json=> (time (do (with-out-str (clojure.data.json/pprint-json data)) nil))
"Elapsed time: 25271.549 msecs"
```

On the other hand, it’s often very handy to see serialized json at which you can look at with a naked eye.

Solution is very simple: just use indentation when printing array and object elements. It’s very fast and straightforward, yet it dramatically changes human ability to look at such JSON. Structure is evident, the only downside being possibility of very long lines.

I modified write-array and write-object, added new `:indent` option to write, and also fixed `(seq m)` thing in write-object (should be `(seq x)`). There’s some performance penalty, of course, but relatively small:

```
clojure.data.json=> (time (do (clojure.data.json/write-str data :indent true) nil))
"Elapsed time: 250.18 msecs"
```
