### PR TITLE
Positional tracking

### DIFF
--- a/src/test/clojure/clojure/data/json_test.clj
+++ b/src/test/clojure/clojure/data/json_test.clj
@@ -265,6 +265,20 @@
 (deftest characters-in-map-keys-are-escaped
   (is (= (json/write-str {"\"" 42}) "{\"\\\"\":42}")))
 
+(deftest track-positions-in-object
+  (let [obj (json/read-str "\n{ \"one\" : \n 7, \n\n  \"two\" : \"second\"}" :track-pos? true)
+        pos (:pos (meta obj))]
+    (is (= (get pos "one") [3 2]))
+    (is (= (get pos "two") [5 11]))))
+
+(deftest track-positions-in-array
+  (let [obj (json/read-str "\n\n[ 1, 2, \n, 3    , \n4\n]" :track-pos? true)
+        pos (:pos (meta obj))]
+    (is (= (get pos 0) [3 3]))
+    (is (= (get pos 1) [3 6]))
+    (is (= (get pos 2) [4 3]))
+    (is (= (get pos 3) [5 1]))))
+
 ;;; Pretty-printer
 
 (deftest pretty-printing
@@ -272,7 +286,7 @@
     (is (= x (json/read-str (with-out-str (json/pprint x)))))))
 
 (deftest pretty-print-nonescaped-unicode
-  (is (= "\"\u1234\u4567\"\n"
+    (is (= "\"\u1234\u4567\"\n"
          (with-out-str
            (json/pprint "\u1234\u4567" :escape-unicode false)))))
 


### PR DESCRIPTION
Putting this forward for consideration.  It adds an optional argument to `clojure.data.json/read`, `:track-pos?`,  that causes the line and column number information for each array and object member to be stored as metadata on the result.  It's something that I'm finding useful for doing validation on a JSON file so that I can report to the user where problems exist.

I'll get my Contributor Agreement in the mail tomorrow.  In the meantime, I thought I'd at least gauge interest in this feature and incorporate any changes that you feel would make the merge more palatable. 
